### PR TITLE
feat: add ECR digest backup/restore and GitOps Slack notification

### DIFF
--- a/backup-ecr-digest/action.yaml
+++ b/backup-ecr-digest/action.yaml
@@ -4,6 +4,12 @@ description: "Backs up ECR Digest in order to eventually restore it to avoid orp
 inputs:
   image-manifests:
     required: true
+  base-image-aws-account-id:
+    description: The AWS account ID where the base image is located.
+    default: "861208160487"
+  base-image-aws-region:
+    description: The AWS region where the base image is located.
+    default: eu-central-1
 
 outputs:
   digests:
@@ -13,6 +19,13 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Configure AWS Credentials
+      uses: CardoAI/composite/ecrlogin_with_role@main
+      if: ${{ (inputs.base-image-aws-region != '') && (inputs.base-image-aws-account-id != '') }}
+      with:
+        aws-region: ${{ inputs.base-image-aws-region }}
+        aws-id: ${{ inputs.base-image-aws-account-id }}
+
     - name: Backup ECR Digest
       id: backup          
       shell: bash
@@ -28,14 +41,13 @@ runs:
           BASE_TAG=$(echo "$manifest" | jq -r '.tag')
           for suffix in $(echo "$manifest" | jq -r '.tag_suffixes[]'); do
             PLATFORM_TAG="${BASE_TAG}-${suffix}"
-            echo "Querying: account=${ACCOUNT_ID} region=${REGION} repo=${REPO} tag=${PLATFORM_TAG}"
             DIGEST=$(aws ecr describe-images \
               --registry-id "$ACCOUNT_ID" \
               --repository-name "$REPO" \
               --region "$REGION" \
               --image-ids "imageTag=${PLATFORM_TAG}" \
               --query 'imageDetails[0].imageDigest' \
-              --output text 2>&1 || echo "NONE")
+              --output text 2>/dev/null || echo "NONE")
             digests=$(echo "$digests" | jq -c --arg k "${REPO}:${PLATFORM_TAG}" --arg v "$DIGEST" '. + {($k): $v}')
           done
         done

--- a/backup-ecr-digest/action.yaml
+++ b/backup-ecr-digest/action.yaml
@@ -1,0 +1,42 @@
+name: "Backup ECR Digest"
+description: "Backs up ECR Digest in order to eventually restore it to avoid orphaned SHAs in use"
+
+inputs:
+  image-manifests:
+    required: true
+
+outputs:
+  digests:
+    description: "JSON map of repo:tag to digest"
+    value: ${{ steps.backup.outputs.digests }}
+
+runs:
+  using: composite
+  steps:
+    - name: Backup ECR Digest
+      id: backup          
+      shell: bash
+      env:
+        IMAGE_MANIFESTS: ${{ inputs.image-manifests }}
+      run: |
+        set -e
+        digests="{}"
+        for manifest in $(echo "$IMAGE_MANIFESTS" | jq -c '.[]'); do
+          ACCOUNT_ID=$(echo "$manifest" | jq -r '.account_id')
+          REGION=$(echo "$manifest" | jq -r '.region')
+          REPO=$(echo "$manifest" | jq -r '.repository')
+          BASE_TAG=$(echo "$manifest" | jq -r '.tag')
+          for suffix in $(echo "$manifest" | jq -r '.tag_suffixes[]'); do
+            PLATFORM_TAG="${BASE_TAG}-${suffix}"
+            DIGEST=$(aws ecr describe-images \
+              --registry-id "$ACCOUNT_ID" \
+              --repository-name "$REPO" \
+              --region "$REGION" \
+              --image-ids "imageTag=${PLATFORM_TAG}" \
+              --query 'imageDetails[0].imageDigest' \
+              --output text 2>/dev/null || echo "NONE")
+            digests=$(echo "$digests" | jq -c --arg k "${REPO}:${PLATFORM_TAG}" --arg v "$DIGEST" '. + {($k): $v}')
+          done
+        done
+        echo "digests=$(echo "$digests" | jq -c .)" >> $GITHUB_OUTPUT
+  

--- a/backup-ecr-digest/action.yaml
+++ b/backup-ecr-digest/action.yaml
@@ -28,13 +28,14 @@ runs:
           BASE_TAG=$(echo "$manifest" | jq -r '.tag')
           for suffix in $(echo "$manifest" | jq -r '.tag_suffixes[]'); do
             PLATFORM_TAG="${BASE_TAG}-${suffix}"
+            echo "Querying: account=${ACCOUNT_ID} region=${REGION} repo=${REPO} tag=${PLATFORM_TAG}"
             DIGEST=$(aws ecr describe-images \
               --registry-id "$ACCOUNT_ID" \
               --repository-name "$REPO" \
               --region "$REGION" \
               --image-ids "imageTag=${PLATFORM_TAG}" \
               --query 'imageDetails[0].imageDigest' \
-              --output text 2>/dev/null || echo "NONE")
+              --output text 2>&1 || echo "NONE")
             digests=$(echo "$digests" | jq -c --arg k "${REPO}:${PLATFORM_TAG}" --arg v "$DIGEST" '. + {($k): $v}')
           done
         done

--- a/notification-gitops/action.yaml
+++ b/notification-gitops/action.yaml
@@ -1,0 +1,33 @@
+name: "GitOps Slack Notification"
+description: "Notify to Slack GitOps channel for failed deployments"
+
+inputs:
+  token:
+    description: "The Slack access token to write messages"
+    required: true
+  channel-id:
+    description: "The Slack Channel ID in which to write"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Send Slack notification
+      uses: slackapi/slack-github-action@v3.0.1
+      with:
+        method: chat.postMessage
+        token: ${{ inputs.token }}
+        payload: |
+          {
+            "channel": "${{ inputs.channel-id }}",
+            "text": "⚠️ GitOps update failed for *${{ github.workflow }}* on `${{ github.ref_name }}`",
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "⚠️ *GitOps Update Failed*\n*Workflow:* ${{ github.workflow }}\n*Branch:* `${{ github.ref_name }}`\n*Region:* EU\n*Run:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"
+                }
+              }
+            ]
+          }

--- a/restore-ecr-digest/action.yaml
+++ b/restore-ecr-digest/action.yaml
@@ -16,12 +16,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Configure AWS Credentials
-      uses: CardoAI/composite/ecrlogin_with_role@main
-      if: ${{ (inputs.base-image-aws-region != '') && (inputs.base-image-aws-account-id != '') }}
-      with:
-        aws-region: ${{ inputs.base-image-aws-region }}
-        aws-id: ${{ inputs.base-image-aws-account-id }}
 
     - name: Restore ECR Digest
       shell: bash

--- a/restore-ecr-digest/action.yaml
+++ b/restore-ecr-digest/action.yaml
@@ -1,0 +1,60 @@
+name: "Restore ECR Digest"
+description: "Restores ECR Digest to avoid orphaned SHAs"
+
+inputs:
+  image-manifests:
+    required: true
+  snapshots:
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Restore ECR Digest
+      shell: bash
+      env:
+        IMAGE_MANIFESTS: ${{ inputs.image-manifests }}
+        SNAPSHOTS: ${{ inputs.snapshots }}
+      run: |
+        set -e
+        for manifest in $(echo "$IMAGE_MANIFESTS" | jq -c '.[]'); do
+          ACCOUNT_ID=$(echo "$manifest" | jq -r '.account_id')
+          REGION=$(echo "$manifest" | jq -r '.region')
+          REPO=$(echo "$manifest" | jq -r '.repository')
+          BASE_TAG=$(echo "$manifest" | jq -r '.tag')
+          for suffix in $(echo "$manifest" | jq -r '.tag_suffixes[]'); do
+            PLATFORM_TAG="${BASE_TAG}-${suffix}"
+            KEY="${REPO}:${PLATFORM_TAG}"
+            OLD_DIGEST=$(echo "$SNAPSHOTS" | jq -r --arg k "$KEY" '.[$k] // "NONE"')
+            if [ "$OLD_DIGEST" = "NONE" ]; then
+              echo "${PLATFORM_TAG}: no snapshot found, skipping"
+              continue
+            fi
+            CURRENT_DIGEST=$(aws ecr describe-images \
+              --registry-id "$ACCOUNT_ID" \
+              --repository-name "$REPO" \
+              --region "$REGION" \
+              --image-ids "imageTag=${PLATFORM_TAG}" \
+              --query 'imageDetails[0].imageDigest' \
+              --output text 2>/dev/null || echo "NONE")
+            if [ "$CURRENT_DIGEST" = "$OLD_DIGEST" ]; then
+              echo "${PLATFORM_TAG}: digest unchanged, no restore needed"
+              continue
+            fi
+            echo "${PLATFORM_TAG}: digest changed (${OLD_DIGEST} -> ${CURRENT_DIGEST}), restoring..."
+            OLD_MANIFEST=$(aws ecr batch-get-image \
+              --registry-id "$ACCOUNT_ID" \
+              --repository-name "$REPO" \
+              --region "$REGION" \
+              --image-ids "imageDigest=${OLD_DIGEST}" \
+              --query 'images[0].imageManifest' \
+              --output text)
+            aws ecr put-image \
+              --registry-id "$ACCOUNT_ID" \
+              --repository-name "$REPO" \
+              --region "$REGION" \
+              --image-tag "$PLATFORM_TAG" \
+              --image-manifest "$OLD_MANIFEST"
+            echo "${PLATFORM_TAG}: restored to ${OLD_DIGEST}"
+          done
+        done

--- a/restore-ecr-digest/action.yaml
+++ b/restore-ecr-digest/action.yaml
@@ -6,10 +6,23 @@ inputs:
     required: true
   snapshots:
     required: true
+  base-image-aws-account-id:
+    description: The AWS account ID where the base image is located.
+    default: "861208160487"
+  base-image-aws-region:
+    description: The AWS region where the base image is located.
+    default: eu-central-1
 
 runs:
   using: composite
   steps:
+    - name: Configure AWS Credentials
+      uses: CardoAI/composite/ecrlogin_with_role@main
+      if: ${{ (inputs.base-image-aws-region != '') && (inputs.base-image-aws-account-id != '') }}
+      with:
+        aws-region: ${{ inputs.base-image-aws-region }}
+        aws-id: ${{ inputs.base-image-aws-account-id }}
+
     - name: Restore ECR Digest
       shell: bash
       env:

--- a/update-image-digest-v2/main.py
+++ b/update-image-digest-v2/main.py
@@ -14,7 +14,7 @@ def get_latest_digest(repository, tag):
 
     account_id = match.group("account_id")
     region = match.group("region")
-    repo_name = match.group("repo_name")
+    repo_name = match.group("repo_name").split(":")[0]
 
     ecr = boto3.client("ecr", region_name=region)
     response = ecr.describe_images(


### PR DESCRIPTION
- backup-ecr-digest: snapshots ECR image digests per tag/suffix to prevent orphaned SHAs
- restore-ecr-digest: restores ECR image digests from snapshots when digests have changed
- notification-gitops: sends Slack alert on failed GitOps deployments