### PR TITLE
Add optional S3 cleanup flag to frontend build action

### DIFF
--- a/build-frontend-v3/action.yaml
+++ b/build-frontend-v3/action.yaml
@@ -5,6 +5,11 @@ inputs:
   working-directory:
     description: Directory containing package.json and yarn.lock.
     default: "."
+  cleanup-bucket:
+    description: "Delete files from s3 that no longer exist on build."
+    default: "false"
+    required: false
+
 
 runs:
   using: composite
@@ -22,3 +27,5 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: $GITHUB_ACTION_PATH/build.sh
+      env:
+        CLEANUP_BUCKET: ${{ inputs.cleanup-bucket }}

--- a/build-frontend-v3/build.sh
+++ b/build-frontend-v3/build.sh
@@ -3,6 +3,8 @@
 : ${BUILD_DIRECTORY:="dist"}
 # Set default value for NODE_OPTIONS if it's not set
 : ${NODE_OPTIONS:="--max-old-space-size=2048"}
+# Set default value for DELETE_OLD_ASSETS if it's not set
+: ${CLEANUP_BUCKET:="false"}
 # Ensure failure on any command failure (set -e)
 set -euo pipefail
 
@@ -24,8 +26,17 @@ NODE_OPTIONS=$NODE_OPTIONS yarn build
 
 # Check if the BUILD_DIRECTORY exists and sync to S3
 if [ -d "$BUILD_DIRECTORY" ]; then
+
+    DELETE_FLAG=""
+    if [ "$DELETE_OLD_ASSETS" = "true" ]; then
+        echo "DELETE_FLAG set to true. Deleting old assets from S3..."
+        DELETE_FLAG="--delete"
+    fi
+
+
     echo "Syncing hashed assets to S3 (no delete, long cache, immutable)..."
     aws s3 sync "$BUILD_DIRECTORY" "s3://$CLOUDFRONT_DISTRIBUTION_BUCKET" \
+        $DELETE_FLAG \
         --exclude "index.html" \
         --cache-control "public,max-age=31536000,immutable"
 


### PR DESCRIPTION
Introduce a `cleanup-bucket` action input and pass it through as `CLEANUP_BUCKET` to the build script so S3 sync can optionally use `--delete` to remove stale assets.