### PR TITLE
Use s3 cp instead of s3 sync for syync-frontend-s3-bucket-v1

### DIFF
--- a/sync-frontend-s3-bucket-v1/action.yaml
+++ b/sync-frontend-s3-bucket-v1/action.yaml
@@ -28,5 +28,5 @@ runs:
         SOURCE_BUCKET: ${{ inputs.source-bucket }}
         DESTINATION_BUCKET: ${{ inputs.destination-bucket }}
       run: |
-        aws s3 sync "s3://${SOURCE_BUCKET}/index.html" "s3://${DESTINATION_BUCKET}/index.html" \
+        aws s3 cp "s3://${SOURCE_BUCKET}/index.html" "s3://${DESTINATION_BUCKET}/index.html" \
           --cache-control "no-cache,no-store,must-revalidate"


### PR DESCRIPTION
This ensures it will always override the destination even if the size of the file matches or the timestamp is larger in destination